### PR TITLE
feat: Implement InstaReveal QR Draw System

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,99 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const qrCodeDisplay = document.getElementById('qr-code-display');
+    const statusMessage = document.getElementById('status-message');
+    const resultImage = document.getElementById('result-image');
+    let pollingIntervalId = null;
+
+    async function generateSessionAndPoll() {
+        try {
+            statusMessage.textContent = 'Generating session...';
+            const response = await fetch('/api/generate-qr-session', {
+                method: 'POST',
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => ({ error: 'Failed to generate session. Server returned an error.' }));
+                throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
+            }
+
+            const data = await response.json();
+            const sessionId = data.sessionId;
+
+            if (!sessionId) {
+                throw new Error('Session ID not received from server.');
+            }
+
+            qrCodeDisplay.textContent = `Session ID: ${sessionId}`;
+            statusMessage.textContent = 'Waiting for pastor to scan...';
+            resultImage.style.display = 'none'; // Ensure image is hidden initially
+
+            // Start polling
+            pollingIntervalId = setInterval(() => {
+                checkStatus(sessionId);
+            }, 2000);
+
+        } catch (error) {
+            console.error('Error in generateSessionAndPoll:', error);
+            statusMessage.textContent = `Error: ${error.message}`;
+            if (pollingIntervalId) {
+                clearInterval(pollingIntervalId);
+            }
+        }
+    }
+
+    async function checkStatus(sessionId) {
+        try {
+            const response = await fetch(`/api/check-status?sessionId=${sessionId}`);
+
+            if (!response.ok) {
+                // If session not found, stop polling as it's a permanent error for this session
+                if (response.status === 404) {
+                    statusMessage.textContent = 'Error: Session ID not found. Please refresh to start a new session.';
+                    if (pollingIntervalId) {
+                        clearInterval(pollingIntervalId);
+                    }
+                } else {
+                    const errorData = await response.json().catch(() => ({ error: 'Failed to check status. Server returned an error.' }));
+                    // For other errors, we might want to keep polling or display a specific message
+                    statusMessage.textContent = `Error checking status: ${errorData.error || `HTTP error! status: ${response.status}`}`;
+                }
+                return; // Don't proceed further if there's an error
+            }
+
+            const data = await response.json();
+
+            if (data.status === 'drawn') {
+                statusMessage.textContent = 'Draw complete!';
+                if (data.result_image_url) {
+                    resultImage.src = data.result_image_url;
+                    resultImage.style.display = 'block';
+                } else {
+                    resultImage.alt = 'Result image not available.';
+                    resultImage.style.display = 'none';
+                    statusMessage.textContent = 'Draw complete! (Image not available)';
+                }
+                if (pollingIntervalId) {
+                    clearInterval(pollingIntervalId);
+                }
+            } else if (data.status === 'pending') {
+                // Optional: Update status message if needed, for now, "Waiting for pastor to scan..." is fine.
+                // statusMessage.textContent = 'Status: Pending...';
+            } else {
+                // Handle other potential statuses if any
+                statusMessage.textContent = `Status: ${data.status || 'Unknown'}`;
+            }
+
+        } catch (error) {
+            console.error('Error in checkStatus:', error);
+            // Display a generic error or more specific if possible
+            statusMessage.textContent = 'Error checking status. Please check your connection.';
+            // Optionally stop polling on certain types of errors
+            // if (pollingIntervalId) {
+            //     clearInterval(pollingIntervalId);
+            // }
+        }
+    }
+
+    // Start the process when the page loads
+    generateSessionAndPoll();
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>InstaReveal QR Draw</title>
+    <style>
+        body {
+            font-family: sans-serif;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            margin: 0;
+            background-color: #f0f0f0;
+        }
+        #container {
+            background-color: white;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+            text-align: center;
+        }
+        #qr-code-display {
+            margin-bottom: 20px;
+            font-size: 1.2em;
+            word-break: break-all;
+        }
+        #status-message {
+            margin-bottom: 20px;
+            font-weight: bold;
+        }
+        #result-image {
+            max-width: 100%;
+            height: auto;
+            margin-top: 10px;
+            border: 1px solid #ccc;
+            display: none; /* Initially hidden */
+        }
+    </style>
+</head>
+<body>
+    <div id="container">
+        <h1>InstaReveal QR Draw</h1>
+        <div id="qr-code-display">Generating session...</div>
+        <div id="status-message">Please wait.</div>
+        <img id="result-image" alt="Result Image">
+    </div>
+    <script src="app.js" defer></script>
+</body>
+</html>

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,147 @@
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const path = url.pathname;
+    const method = request.method;
+
+    if (method === "POST" && path === "/api/generate-qr-session") {
+      return handleGenerateQRSession(request, env);
+    } else if (method === "POST" && path === "/api/pastor-scan") {
+      return handlePastorScan(request, env);
+    } else if (method === "GET" && path === "/api/check-status") {
+      return handleCheckStatus(request, env);
+    } else {
+      return new Response("Not Found", { status: 404 });
+    }
+  },
+};
+
+async function handleGenerateQRSession(request, env) {
+  try {
+    const sessionId = crypto.randomUUID();
+    const createdAt = new Date().toISOString();
+
+    const stmt = env.DB.prepare(
+      "INSERT INTO sessions (session_id, status, created_at) VALUES (?, ?, ?)"
+    );
+    await stmt.bind(sessionId, "pending", createdAt).run();
+
+    return new Response(JSON.stringify({ sessionId }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    console.error("Error generating QR session:", error);
+    return new Response(
+      JSON.stringify({ success: false, error: "Database error" }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  }
+}
+
+async function handlePastorScan(request, env) {
+  try {
+    const { sessionId } = await request.json();
+    if (!sessionId) {
+      return new Response(
+        JSON.stringify({ success: false, error: "Missing sessionId" }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    const images = ["img1.jpg", "img2.jpg", "img3.jpg"];
+    const randomImage = images[Math.floor(Math.random() * images.length)];
+    const drawnAt = new Date().toISOString();
+
+    const stmt = env.DB.prepare(
+      "UPDATE sessions SET status = ?, drawn_at = ?, result_image_url = ? WHERE session_id = ?"
+    );
+    const info = await stmt.bind("drawn", drawnAt, randomImage, sessionId).run();
+
+    if (info.changes === 0) {
+      return new Response(
+        JSON.stringify({ success: false, error: "Session not found" }),
+        {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({ success: true, message: "Session updated." }),
+      {
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  } catch (error) {
+    console.error("Error in pastor scan:", error);
+    // Check if the error is due to invalid JSON
+    if (error instanceof SyntaxError) {
+        return new Response(
+            JSON.stringify({ success: false, error: "Invalid JSON body" }),
+            {
+                status: 400,
+                headers: { "Content-Type": "application/json" },
+            }
+        );
+    }
+    return new Response(
+      JSON.stringify({ success: false, error: "Database error or invalid request" }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  }
+}
+
+async function handleCheckStatus(request, env) {
+  const url = new URL(request.url);
+  const sessionId = url.searchParams.get("sessionId");
+
+  if (!sessionId) {
+    return new Response(
+      JSON.stringify({ error: "Missing sessionId parameter" }),
+      {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  }
+
+  try {
+    const stmt = env.DB.prepare(
+      "SELECT status, result_image_url FROM sessions WHERE session_id = ?"
+    );
+    const session = await stmt.bind(sessionId).first();
+
+    if (session) {
+      return new Response(
+        JSON.stringify({
+          status: session.status,
+          result_image_url: session.result_image_url,
+        }),
+        {
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    } else {
+      return new Response(JSON.stringify({ error: "Session not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+  } catch (error) {
+    console.error("Error checking status:", error);
+    return new Response(JSON.stringify({ error: "Database error" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}


### PR DESCRIPTION
Adds a Cloudflare backend and a participant frontend for the InstaReveal QR Draw system.

Backend:
- POST /api/generate-qr-session: Creates a new session in Cloudflare D1, status "pending".
- POST /api/pastor-scan: Updates session to "drawn", records a randomly selected result_image_url.
- GET /api/check-status?sessionId=ID: Fetches session status and result_image_url.
- Uses Cloudflare D1 for session storage (table: sessions).

Frontend (index.html & app.js):
- Calls /api/generate-qr-session to get a sessionId.
- Displays the sessionId (placeholder for QR code).
- Polls /api/check-status every 2 seconds.
- If status is "drawn", displays the result_image_url and stops polling.